### PR TITLE
Enable test-coverage DeepSource analyzer

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -5,3 +5,7 @@ name = "python"
 
   [analyzers.meta]
   runtime_version = "3.x.x"
+
+[[analyzers]]
+name = "test-coverage"
+enabled = true

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -18,7 +18,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest ]
         python-version: [ "3.11" ]
 
     uses: darbiadev/.github/.github/workflows/python-test.yaml@64b318dffebca7a441217225ecb3fcb548358854 # v8.1.0

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -21,7 +21,7 @@ jobs:
         os: [ ubuntu-latest ]
         python-version: [ "3.11" ]
 
-    uses: darbiadev/.github/.github/workflows/python-test.yaml@64b318dffebca7a441217225ecb3fcb548358854 # v8.1.0
+    uses: darbiadev/.github/.github/workflows/python-test.yaml@6a6eb74ae11149881c29adf5a5f7af23349c8762 # v9.0.0
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Why do these things have to be explicitly enabled??