### PR TITLE
Update .readthedocs.yaml to not pin tooling versions

### DIFF
--- a/docs/source/.readthedocs.yaml
+++ b/docs/source/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
-    python: "3"
+    python: latest
 
 python:
   install:

--- a/docs/source/.readthedocs.yaml
+++ b/docs/source/.readthedocs.yaml
@@ -1,16 +1,13 @@
 version: 2
-
 build:
   os: ubuntu-lts-latest
   tools:
     python: latest
-
 python:
   install:
     - method: pip
       path: .
       extra_requirements:
         - docs
-
 sphinx:
    configuration: docs/source/conf.py


### PR DESCRIPTION
https://github.com/readthedocs/readthedocs.org/pull/11081